### PR TITLE
feat: improved unmarshaling

### DIFF
--- a/read.go
+++ b/read.go
@@ -12,11 +12,13 @@
 package exl
 
 import (
+	"encoding"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"reflect"
-	"strings"
+	"time"
 
 	"github.com/tealeg/xlsx/v3"
 )
@@ -24,27 +26,176 @@ import (
 type (
 	ReadConfigurator interface{ ReadConfigure(rc *ReadConfig) }
 	ReadConfig       struct {
-		TagName           string
-		SheetIndex        int
-		HeaderRowIndex    int
+		// The tag name to use when looking for fields in the target struct.
+		// Defaults to "excel".
+		TagName string
+		// The index of the worksheet to be read.
+		// Defaults to 0, the first worksheet.
+		SheetIndex int
+		// The row index at which the column headers are read from.
+		// Zero-based, defaults to 0.
+		HeaderRowIndex int
+		// Start the data reading at this row.
+		// The header row counts as row.
+		// Zero-based, defaults to 1.
 		DataStartRowIndex int
-		TrimSpace         bool
+		// Configure the default string unmarshaler to trim space after reading a cell.
+		// Does not impact any other default unmarshaler,
+		// but is available to custom unmarshalers via ExcelUnmarshalParameters.TrimSpace.
+		// Defaults to false.
+		TrimSpace bool
+		// Fallback date formats for date parsing.
+		// If an Excel cell is to be unmarshalled into a date,
+		// and that cell is either not formatted as Date or contains raw text
+		// (which can happen if Excel does not correctly recognize the date format)
+		// then these formats are used in the order specified to try and parse
+		// the raw cell value into a date.
+		// There are no fallback formats configured by default.
+		FallbackDateFormats []string
+		// Skip reading columns for which no target field is found.
+		// Defaults to true.
+		SkipUnknownColumns bool
+		// Skip reading columns, if there is a target field,
+		// but the target type is unsupported
+		// or caused an error when determining the unmarshaler to use.
+		// Defaults to false.
+		SkipUnknownTypes bool
+		// Configure how errors during unmarshaling are handled.
+		// Unmarshaling errors are e.g. invalid number formats in the cell,
+		// date parsing with invalid input,
+		// or attempting to unmarshal non-numeric text into a numeric field.
+		// Defaults to UnmarshalErrorAbort.
+		UnmarshalErrorHandling UnmarshalErrorHandling
+		// If UnmarshalErrorHandling is configured as UnmarshalErrorCollect,
+		// this option limits the number of errors which are collected before
+		// parsing is aborted.
+		// Configure a limit of 0 to collect all errors, without upper limit.
+		// Defaults to 10.
+		MaxUnmarshalErrors uint64
+	}
+	UnmarshalErrorHandling uint8
+	FieldError             struct {
+		RowIndex     int // 0-based row index. Printed as 1-based row number in error text.
+		ColumnIndex  int // 0-based column index.
+		ColumnHeader string
+		Err          error
+	}
+	ContentError struct {
+		FieldErrors  []FieldError
+		LimitReached bool
 	}
 )
 
 var (
-	defaultReadConfig              = func() *ReadConfig { return &ReadConfig{TagName: "excel", DataStartRowIndex: 1} }
+	// Ensure FieldError implements the error interface
+	_ error = FieldError{}
+	// Ensure FieldError can be unwrapped
+	_ interface {
+		Unwrap() error
+	} = FieldError{}
+	// Ensure ContentError implements the error interface
+	_ error = ContentError{}
+)
+
+// Error implements error.
+func (e FieldError) Error() string {
+	return fmt.Sprintf("error unmarshaling column \"%s\" in row %d: %s", e.ColumnHeader, e.RowIndex+1, e.Err.Error())
+}
+
+// Error implements the anonymous unwrap interface used by errors.Unwrap and others.
+func (e FieldError) Unwrap() error {
+	return e.Err
+}
+
+// Error implements error.
+func (e ContentError) Error() string {
+	if e.LimitReached {
+		return fmt.Sprintf("too many (%d) errors reading data from Excel", len(e.FieldErrors))
+	} else {
+		return fmt.Sprintf("%d errors reading data from Excel", len(e.FieldErrors))
+	}
+}
+
+// Error implements the anonymous unwrap interface used by errors.Unwrap and others.
+func (e ContentError) Unwrap() []error {
+	// Slice needs to be type-adjusted
+	errs := make([]error, len(e.FieldErrors))
+	for i, v := range e.FieldErrors {
+		errs[i] = v
+	}
+	return errs
+}
+
+const (
+	// Ignore any errors during unmarshaling
+	UnmarshalErrorIgnore UnmarshalErrorHandling = iota
+	// Abort reading when encountering the first unmarshaling error
+	UnmarshalErrorAbort
+	// Collect unmarshaling errors up to a limit, but continue reading.
+	// Collected errors are returned as one error at the end, of type
+	UnmarshalErrorCollect
+)
+
+var (
+	defaultReadConfig = func() *ReadConfig {
+		return &ReadConfig{
+			TagName:                "excel",
+			DataStartRowIndex:      1,
+			SkipUnknownColumns:     true,
+			UnmarshalErrorHandling: UnmarshalErrorAbort,
+			MaxUnmarshalErrors:     10,
+		}
+	}
 	ErrSheetIndexOutOfRange        = errors.New("exl: sheet index out of range")
 	ErrHeaderRowIndexOutOfRange    = errors.New("exl: header row index out of range")
 	ErrDataStartRowIndexOutOfRange = errors.New("exl: data start row index out of range")
+	ErrNoUnmarshaler               = errors.New("no unmarshaler")
+	ErrNoDestinationField          = errors.New("no destination field with matching tag")
 )
 
-func read(maxCol int, row *xlsx.Row) []string {
-	ls := make([]string, maxCol, maxCol)
+func readStrings(maxCol int, row *xlsx.Row) []string {
+	ls := make([]string, maxCol)
 	for i := 0; i < maxCol; i++ {
 		ls[i] = row.GetCell(i).Value
 	}
 	return ls
+}
+
+func GetUnmarshalFunc(destField reflect.Value) UnmarshalExcelFunc {
+	if destField.CanInterface() {
+
+		intf := getFieldInterface(destField)
+		if intf != nil {
+
+			// Prefer ExcelUnmarshaler, if implemented
+			if _, ok := intf.(ExcelUnmarshaler); ok {
+				return UnmarshalExcelUnmarshaler
+			}
+
+			// Then handle specific types with special implementation
+			if destField.Type() == reflect.TypeOf(time.Time{}) {
+				return UnmarshalTime
+			}
+
+			// Then utilize TextUnmarshaler, e.g. for things like decimal.Decimal
+			if _, ok := intf.(encoding.TextUnmarshaler); ok {
+				return UnmarshalTextUnmarshaler
+			}
+
+		}
+	}
+
+	// And for primitive types, use custom unmarshaling funcs
+	kind := destField.Type().Kind()
+	if kind == reflect.Ptr {
+		kind = destField.Type().Elem().Kind()
+	}
+	unmarshalFunc, ok := DefaultUnmarshalFuncs[kind]
+	if ok {
+		return unmarshalFunc
+	}
+
+	return nil
 }
 
 // Read io.Reader each row bind to `T`
@@ -84,35 +235,115 @@ func ReadBinary[T ReadConfigurator](bytes []byte, filterFunc ...func(t T) (add b
 	if rc.DataStartRowIndex < 0 || rc.DataStartRowIndex > sheet.MaxRow-1 {
 		return nil, ErrDataStartRowIndexOutOfRange
 	}
-	trimSpace := rc.TrimSpace
 	headerRow, _ := sheet.Row(rc.HeaderRowIndex)
 	maxCol := sheet.MaxCol
-	headers := read(maxCol, headerRow)
-	headerMap := make(map[int]string, maxCol)
-	for i, h := range headers {
-		headerMap[i] = h
+	headers := readStrings(maxCol, headerRow)
+	type fieldInfo struct {
+		reflectFieldIndex int
+		header            string
+		unmarshalFunc     UnmarshalExcelFunc
 	}
-	fieldMap := make(map[string]int, 0)
+	// Key: Header / Tag name
+	// Value: Reflection field index
+	tagToFieldMap := make(map[string]int, 0)
+	// Key: Column Index
+	// Value: Unmarshaling Info
+	columnFields := make([]fieldInfo, len(headers))
+
 	typ := reflect.TypeOf(t).Elem()
 	for i := 0; i < typ.NumField(); i++ {
 		if ta := typ.Field(i).Tag; ta != "" {
 			if tt, have := ta.Lookup(rc.TagName); have {
-				fieldMap[tt] = i
+				tagToFieldMap[tt] = i
 			}
 		}
 	}
+
+	{
+		val := reflect.New(typ).Elem()
+
+		for columnIndex, header := range headers {
+			reflectFieldIndex, have := tagToFieldMap[header]
+			if !have {
+				if rc.SkipUnknownColumns {
+					// Skip reading this field
+					columnFields[columnIndex] = fieldInfo{
+						reflectFieldIndex: reflectFieldIndex,
+						header:            header,
+						unmarshalFunc:     nil,
+					}
+					continue
+				} else {
+					return nil, fmt.Errorf("%w for column \"%s\" at index %d", ErrNoDestinationField, header, columnIndex)
+				}
+			}
+
+			field := val.Field(reflectFieldIndex)
+
+			unmarshaler := GetUnmarshalFunc(field)
+			if unmarshaler == nil {
+				if rc.SkipUnknownTypes {
+					// Skip reading this field
+					columnFields[columnIndex] = fieldInfo{
+						reflectFieldIndex: reflectFieldIndex,
+						header:            header,
+						unmarshalFunc:     nil,
+					}
+					continue
+				} else {
+					return nil, fmt.Errorf("%w for column \"%s\" at index %d", ErrNoUnmarshaler, header, columnIndex)
+				}
+			}
+
+			columnFields[columnIndex] = fieldInfo{
+				reflectFieldIndex: reflectFieldIndex,
+				header:            header,
+				unmarshalFunc:     unmarshaler,
+			}
+		}
+	}
+
+	unmarshalConfig := &ExcelUnmarshalParameters{
+		TrimSpace:           rc.TrimSpace,
+		Date1904:            f.Date1904,
+		FallbackDateFormats: rc.FallbackDateFormats,
+	}
+
+	collectedErrors := make([]FieldError, 0)
+
 	ts := make([]T, 0)
-	for i := 0; i < sheet.MaxRow; i++ {
-		if i >= rc.DataStartRowIndex {
+	for rowIndex := 0; rowIndex < sheet.MaxRow; rowIndex++ {
+		if rowIndex >= rc.DataStartRowIndex {
 			val := reflect.New(typ).Elem()
-			if row, _ := sheet.Row(i); row != nil {
-				for di, d := range read(maxCol, row) {
-					if header, have := headerMap[di]; have {
-						if fi, fa := fieldMap[header]; fa {
-							fie := val.Field(fi)
-							setValue(reflect.ValueOf(d), fie)
-							if trimSpace && (fie.Type().Kind() == reflect.String || (fie.Type().Kind() == reflect.Ptr && fie.Type().Elem().Kind() == reflect.String)) {
-								fie.SetString(strings.TrimSpace(fie.String()))
+			if row, _ := sheet.Row(rowIndex); row != nil {
+
+				for columnIndex, fi := range columnFields {
+					// If there is no unmarshal function,
+					// this field has been skipped by previous logic.
+					// e.g. no destination field, or unknown type.
+					if fi.unmarshalFunc == nil {
+						continue
+					}
+					cell := row.GetCell(columnIndex)
+
+					destField := val.Field(fi.reflectFieldIndex)
+					err = fi.unmarshalFunc(destField, cell, unmarshalConfig)
+					if err != nil && rc.UnmarshalErrorHandling != UnmarshalErrorIgnore {
+						ferr := FieldError{
+							RowIndex:     rowIndex,
+							ColumnIndex:  columnIndex,
+							ColumnHeader: fi.header,
+							Err:          err,
+						}
+						if rc.UnmarshalErrorHandling == UnmarshalErrorAbort {
+							return nil, ferr
+						} else {
+							collectedErrors = append(collectedErrors, ferr)
+							if rc.MaxUnmarshalErrors > 0 && uint64(len(collectedErrors)) >= rc.MaxUnmarshalErrors {
+								return nil, ContentError{
+									FieldErrors:  collectedErrors,
+									LimitReached: true,
+								}
 							}
 						}
 					}
@@ -133,6 +364,12 @@ func ReadBinary[T ReadConfigurator](bytes []byte, filterFunc ...func(t T) (add b
 					ts = append(ts, nT)
 				}
 			}
+		}
+	}
+	if len(collectedErrors) > 0 {
+		return nil, ContentError{
+			FieldErrors:  collectedErrors,
+			LimitReached: false,
 		}
 	}
 	return ts, nil

--- a/value_test.go
+++ b/value_test.go
@@ -12,221 +12,310 @@
 package exl
 
 import (
+	"math"
 	"reflect"
 	"testing"
+	"time"
+
+	"github.com/tealeg/xlsx/v3"
 )
 
-type (
-	_model struct {
-		S string
-		B bool
-		I int64
-		U uint64
-		F float64
+type _model struct {
+	S   string
+	B   bool
+	I   int64
+	I8  int8
+	U   uint64
+	U8  uint8
+	F   float64
+	F32 float32
+	T   time.Time
 
-		A any
-	}
-	_testCase struct {
-		expect interface{}
-		src    interface{}
-		ptr    *_model
-	}
-)
-
-func TestValueString(t *testing.T) {
-	cases := make([]*_testCase, 0)
-	// test for String->String
-	{
-		cases = append(cases, &_testCase{"apple", "apple", &_model{}})
-		cases = append(cases, &_testCase{"orange", "orange", &_model{}})
-		cases = append(cases, &_testCase{"banana", "banana", &_model{}})
-	}
-	// test for Bool->String
-	{
-		cases = append(cases, &_testCase{"true", true, &_model{}})
-		cases = append(cases, &_testCase{"false", false, &_model{}})
-	}
-	// test for Int->String
-	{
-		cases = append(cases, &_testCase{"100", 100, &_model{}})
-		cases = append(cases, &_testCase{"100", int8(100), &_model{}})
-		cases = append(cases, &_testCase{"100", int16(100), &_model{}})
-		cases = append(cases, &_testCase{"100", int32(100), &_model{}})
-		cases = append(cases, &_testCase{"100", int64(100), &_model{}})
-	}
-	// test for Uint->String
-	{
-		cases = append(cases, &_testCase{"100", uint(100), &_model{}})
-		cases = append(cases, &_testCase{"100", uint8(100), &_model{}})
-		cases = append(cases, &_testCase{"100", uint16(100), &_model{}})
-		cases = append(cases, &_testCase{"100", uint32(100), &_model{}})
-		cases = append(cases, &_testCase{"100", uint64(100), &_model{}})
-	}
-	// test for Float->String
-	{
-		cases = append(cases, &_testCase{"100", 100, &_model{}})
-		cases = append(cases, &_testCase{"100.25", 100.25, &_model{}})
-		cases = append(cases, &_testCase{"100", float32(100), &_model{}})
-		cases = append(cases, &_testCase{"100.25", float32(100.25), &_model{}})
-	}
-	// test for Array->String
-	{
-		cases = append(cases, &_testCase{"[]", [0]string{}, &_model{}})
-	}
-	// test for Slice->String
-	{
-		cases = append(cases, &_testCase{"[]", []string{}, &_model{}})
-	}
-	// test for map->String
-	{
-		cases = append(cases, &_testCase{"map[apple:100]", map[string]string{"apple": "100"}, &_model{}})
-	}
-	// test for Struct->String
-	{
-		cases = append(cases, &_testCase{"{}", struct{}{}, &_model{}})
-		cases = append(cases, &_testCase{"{100}", struct{ id int }{100}, &_model{}})
-		cases = append(cases, &_testCase{"{100}", struct{ apple string }{"100"}, &_model{}})
-	}
-	for _, c := range cases {
-		setValue(reflect.ValueOf(c.src), reflect.ValueOf(c.ptr).Elem().FieldByName("S"))
-		equal(t, c.expect, c.ptr.S)
-	}
+	A any
 }
 
-func TestValueBool(t *testing.T) {
-	cases := make([]*_testCase, 0)
-	// test for String->Bool
-	{
-		cases = append(cases, &_testCase{true, "true", &_model{}})
-		cases = append(cases, &_testCase{false, "false", &_model{}})
-	}
-	// test for Bool->Bool
-	{
-		cases = append(cases, &_testCase{true, true, &_model{}})
-		cases = append(cases, &_testCase{false, false, &_model{}})
-	}
-	for _, c := range cases {
-		setValue(reflect.ValueOf(c.src), reflect.ValueOf(c.ptr).Elem().FieldByName("B"))
-		equal(t, c.expect, c.ptr.B)
-	}
+func TestUnmarshalString(t *testing.T) {
+	model := &_model{}
+	destField := reflect.ValueOf(model).Elem().FieldByName("S")
+	cell := &xlsx.Cell{}
+
+	t.Run("string cell", func(t *testing.T) {
+		cell.SetValue("string value")
+		err := UnmarshalString(destField, cell, &ExcelUnmarshalParameters{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		equal(t, "string value", model.S)
+	})
+
+	t.Run("formatted cell", func(t *testing.T) {
+		cell.SetFloatWithFormat(17.3, "0.00e+00")
+		err := UnmarshalString(destField, cell, &ExcelUnmarshalParameters{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		equal(t, "1.730000e+01", model.S)
+	})
+
+	t.Run("don't trim space if not configured", func(t *testing.T) {
+		cell.SetValue("  string value  ")
+		err := UnmarshalString(destField, cell, &ExcelUnmarshalParameters{
+			TrimSpace: false,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		equal(t, "  string value  ", model.S)
+	})
+
+	t.Run("trim space if configured", func(t *testing.T) {
+		cell.SetValue("  string value  ")
+		err := UnmarshalString(destField, cell, &ExcelUnmarshalParameters{
+			TrimSpace: true,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		equal(t, "string value", model.S)
+	})
 }
 
-func TestValueInt(t *testing.T) {
-	expect := int64(100)
-	cases := make([]*_testCase, 0)
-	// test for String->Int
-	{
-		cases = append(cases, &_testCase{expect, "100", &_model{}})
-		cases = append(cases, &_testCase{expect, "100.0", &_model{}})
-		cases = append(cases, &_testCase{expect, "100.25", &_model{}})
-	}
-	// test for Uint->Int
-	{
-		cases = append(cases, &_testCase{expect, uint(100), &_model{}})
-		cases = append(cases, &_testCase{expect, uint8(100), &_model{}})
-		cases = append(cases, &_testCase{expect, uint16(100), &_model{}})
-		cases = append(cases, &_testCase{expect, uint32(100), &_model{}})
-		cases = append(cases, &_testCase{expect, uint64(100), &_model{}})
-	}
-	// test for Float->Int
-	{
-		cases = append(cases, &_testCase{expect, 100.0, &_model{}})
-		cases = append(cases, &_testCase{expect, 100.25, &_model{}})
-		cases = append(cases, &_testCase{expect, float32(100), &_model{}})
-		cases = append(cases, &_testCase{expect, float64(100), &_model{}})
-	}
-	// test for Int->Int
-	{
-		cases = append(cases, &_testCase{expect, 100, &_model{}})
-	}
-	for _, c := range cases {
-		setValue(reflect.ValueOf(c.src), reflect.ValueOf(c.ptr).Elem().FieldByName("I"))
-		equal(t, c.expect, c.ptr.I)
-	}
+func TestUnmarshalBool(t *testing.T) {
+	model := &_model{}
+	destField := reflect.ValueOf(model).Elem().FieldByName("B")
+	cell := &xlsx.Cell{}
+
+	t.Run("true cell", func(t *testing.T) {
+		cell.SetBool(true)
+		err := UnmarshalBool(destField, cell, &ExcelUnmarshalParameters{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		equal(t, true, model.B)
+	})
+
+	t.Run("false cell", func(t *testing.T) {
+		cell.SetBool(false)
+		err := UnmarshalBool(destField, cell, &ExcelUnmarshalParameters{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		equal(t, false, model.B)
+	})
 }
 
-func TestValueUint(t *testing.T) {
-	expect := uint64(100)
-	cases := make([]*_testCase, 0)
-	// test for String->Uint
-	{
-		cases = append(cases, &_testCase{expect, "100", &_model{}})
-		cases = append(cases, &_testCase{expect, "100.0", &_model{}})
-		cases = append(cases, &_testCase{expect, "100.25", &_model{}})
-	}
-	// test for Int->Uint
-	{
-		cases = append(cases, &_testCase{expect, 100, &_model{}})
-		cases = append(cases, &_testCase{expect, int8(100), &_model{}})
-		cases = append(cases, &_testCase{expect, int16(100), &_model{}})
-		cases = append(cases, &_testCase{expect, int32(100), &_model{}})
-		cases = append(cases, &_testCase{expect, int64(100), &_model{}})
-	}
-	// test for Float->Uint
-	{
-		cases = append(cases, &_testCase{expect, 100.0, &_model{}})
-		cases = append(cases, &_testCase{expect, 100.25, &_model{}})
-		cases = append(cases, &_testCase{expect, float32(100), &_model{}})
-		cases = append(cases, &_testCase{expect, float64(100), &_model{}})
-	}
-	// test for Uint->Uint
-	{
-		cases = append(cases, &_testCase{expect, uint(100), &_model{}})
-	}
-	for _, c := range cases {
-		setValue(reflect.ValueOf(c.src), reflect.ValueOf(c.ptr).Elem().FieldByName("U"))
-		equal(t, c.expect, c.ptr.U)
-	}
+func TestUnmarshalInt(t *testing.T) {
+	model := &_model{}
+	destField := reflect.ValueOf(model).Elem().FieldByName("I")
+	cell := &xlsx.Cell{}
+
+	t.Run("positive integer cell", func(t *testing.T) {
+		cell.SetValue(123)
+		err := UnmarshalInt(destField, cell, &ExcelUnmarshalParameters{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		equal(t, int64(123), model.I)
+	})
+
+	t.Run("negative integer cell", func(t *testing.T) {
+		cell.SetValue(-123)
+		err := UnmarshalInt(destField, cell, &ExcelUnmarshalParameters{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		equal(t, int64(-123), model.I)
+	})
+
+	t.Run("text cell", func(t *testing.T) {
+		cell.SetValue("123")
+		err := UnmarshalInt(destField, cell, &ExcelUnmarshalParameters{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		equal(t, int64(123), model.I)
+	})
+
+	t.Run("float cell", func(t *testing.T) {
+		cell.SetValue(123.7)
+		err := UnmarshalInt(destField, cell, &ExcelUnmarshalParameters{})
+		if err == nil {
+			t.Fatal("expected format error")
+		}
+	})
+
+	t.Run("overflow", func(t *testing.T) {
+		destFieldOverflow := reflect.ValueOf(model).Elem().FieldByName("I8")
+		cell.SetValue(math.MaxInt8 + 1)
+		err := UnmarshalInt(destFieldOverflow, cell, &ExcelUnmarshalParameters{})
+		if err == nil {
+			t.Fatal("expected overflow error")
+		}
+	})
 }
 
-func TestValueFloat(t *testing.T) {
-	expect := float64(100)
-	cases := make([]*_testCase, 0)
-	// test for String->Float
-	{
-		cases = append(cases, &_testCase{expect, "100", &_model{}})
-		cases = append(cases, &_testCase{expect, "100.0", &_model{}})
-		cases = append(cases, &_testCase{expect, "100.00", &_model{}})
-	}
-	// test for Int->Float
-	{
-		cases = append(cases, &_testCase{expect, 100, &_model{}})
-		cases = append(cases, &_testCase{expect, int8(100), &_model{}})
-		cases = append(cases, &_testCase{expect, int16(100), &_model{}})
-		cases = append(cases, &_testCase{expect, int32(100), &_model{}})
-		cases = append(cases, &_testCase{expect, int64(100), &_model{}})
-	}
-	// test for Uint->Float
-	{
-		cases = append(cases, &_testCase{expect, uint(100), &_model{}})
-		cases = append(cases, &_testCase{expect, uint8(100), &_model{}})
-		cases = append(cases, &_testCase{expect, uint16(100), &_model{}})
-		cases = append(cases, &_testCase{expect, uint32(100), &_model{}})
-		cases = append(cases, &_testCase{expect, uint64(100), &_model{}})
-	}
-	// test for Float->Float
-	{
-		cases = append(cases, &_testCase{expect, 100.0, &_model{}})
-		cases = append(cases, &_testCase{expect, 100.00, &_model{}})
-		cases = append(cases, &_testCase{expect, float32(100), &_model{}})
-		cases = append(cases, &_testCase{expect, float64(100), &_model{}})
-	}
-	for _, c := range cases {
-		setValue(reflect.ValueOf(c.src), reflect.ValueOf(c.ptr).Elem().FieldByName("F"))
-		equal(t, c.expect, c.ptr.F)
-	}
+func TestUnmarshalUInt(t *testing.T) {
+	model := &_model{}
+	destField := reflect.ValueOf(model).Elem().FieldByName("U")
+	cell := &xlsx.Cell{}
+
+	t.Run("positive integer cell", func(t *testing.T) {
+		cell.SetValue(123)
+		err := UnmarshalUInt(destField, cell, &ExcelUnmarshalParameters{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		equal(t, uint64(123), model.U)
+	})
+
+	t.Run("negative integer cell: error", func(t *testing.T) {
+		cell.SetValue(-123)
+		err := UnmarshalUInt(destField, cell, &ExcelUnmarshalParameters{})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("text cell", func(t *testing.T) {
+		cell.SetValue("123")
+		err := UnmarshalUInt(destField, cell, &ExcelUnmarshalParameters{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		equal(t, uint64(123), model.U)
+	})
+
+	t.Run("float cell", func(t *testing.T) {
+		cell.SetValue(123.7)
+		err := UnmarshalUInt(destField, cell, &ExcelUnmarshalParameters{})
+		if err == nil {
+			t.Fatal("expected format error")
+		}
+	})
+
+	t.Run("overflow", func(t *testing.T) {
+		destFieldOverflow := reflect.ValueOf(model).Elem().FieldByName("U8")
+		cell.SetValue(math.MaxUint8 + 1)
+		err := UnmarshalUInt(destFieldOverflow, cell, &ExcelUnmarshalParameters{})
+		if err == nil {
+			t.Fatal("expected overflow error")
+		}
+	})
 }
 
-func TestValueAny(t *testing.T) {
-	type arg struct{ ID uint }
-	src := &arg{100}
-	data := &arg{}
-	setValue(reflect.ValueOf(src).Elem(), reflect.ValueOf(data).Elem())
-	equal(t, src, data)
+func TestUnmarshalFloat(t *testing.T) {
+	model := &_model{}
+	destField := reflect.ValueOf(model).Elem().FieldByName("F")
+	cell := &xlsx.Cell{}
+
+	t.Run("positive float cell", func(t *testing.T) {
+		cell.SetValue(123.7)
+		err := UnmarshalFloat(destField, cell, &ExcelUnmarshalParameters{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		equal(t, 123.7, model.F)
+	})
+
+	t.Run("negative float cell", func(t *testing.T) {
+		cell.SetValue(-123.7)
+		err := UnmarshalFloat(destField, cell, &ExcelUnmarshalParameters{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		equal(t, -123.7, model.F)
+	})
+
+	t.Run("text cell", func(t *testing.T) {
+		cell.SetValue("123.7")
+		err := UnmarshalFloat(destField, cell, &ExcelUnmarshalParameters{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		equal(t, 123.7, model.F)
+	})
+
+	t.Run("int cell", func(t *testing.T) {
+		cell.SetValue(123)
+		err := UnmarshalFloat(destField, cell, &ExcelUnmarshalParameters{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		equal(t, 123.0, model.F)
+	})
+
+	t.Run("int cell", func(t *testing.T) {
+		destFieldOverflow := reflect.ValueOf(model).Elem().FieldByName("F32")
+		cell.SetValue(math.MaxFloat64)
+		err := UnmarshalFloat(destFieldOverflow, cell, &ExcelUnmarshalParameters{})
+		if err == nil {
+			t.Fatal("expected overflow error")
+		}
+	})
 }
 
-func equal(t *testing.T, a, b any) {
-	if !reflect.DeepEqual(a, b) {
-		t.Error("test failed!")
+func TestUnmarshalTime(t *testing.T) {
+	model := &_model{}
+	destField := reflect.ValueOf(model).Elem().FieldByName("T")
+	cell := &xlsx.Cell{}
+
+	// NOTE: Testing with too accurate of a date may result in floating point errors.
+	testTime := time.Date(2023, time.November, 13, 14, 15, 0, 0, time.UTC)
+	testTimeFormatted := testTime.Format(time.RFC3339)
+
+	t.Run("date cell", func(t *testing.T) {
+		cell.SetDate(testTime)
+		err := UnmarshalTime(destField, cell, &ExcelUnmarshalParameters{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		equal(t, testTime, model.T)
+	})
+
+	t.Run("date cell with fallback value", func(t *testing.T) {
+		cell.SetDate(testTime)
+		cell.Value = testTimeFormatted
+		err := UnmarshalTime(destField, cell, &ExcelUnmarshalParameters{
+			FallbackDateFormats: []string{time.RFC3339},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		equal(t, testTime, model.T)
+	})
+
+	t.Run("date cell with unparsable value", func(t *testing.T) {
+		cell.SetDate(testTime)
+		cell.Value = "rubbish"
+		err := UnmarshalTime(destField, cell, &ExcelUnmarshalParameters{})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("text cell with fallback value", func(t *testing.T) {
+		cell.SetString(testTimeFormatted)
+		err := UnmarshalTime(destField, cell, &ExcelUnmarshalParameters{
+			FallbackDateFormats: []string{time.RFC3339},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		equal(t, testTime, model.T)
+	})
+
+	t.Run("text cell with unparsable value", func(t *testing.T) {
+		cell.SetString("rubbish")
+		err := UnmarshalTime(destField, cell, &ExcelUnmarshalParameters{})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func equal(t *testing.T, expected, actual any) {
+	t.Helper()
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("test failed, expected \"%v\", got \"%v\"", expected, actual)
 	}
 }


### PR DESCRIPTION
* Refactor internals to a more generic unmarshaling approach,
  and with less reflection happening inside the actual parsing loop
* Implement ExcelUnmarshaler interface
* Support TextUnmarshaler as fallback
* Allow configuration of error handling:
  * Ignore or Abort when encountering missing fields
    (too many columns in excel)
  * Ignore or Abort when encounering unknown field types
  * Ignore, Abort or Collect parsing errors for the actual data

While these changes should be backwards-compatibly with the previous versions, there will be small changes in handling of certain edge cases.
That makes this technically a **breaking change**.