### PR TITLE
Don't copy files into memory if possible

### DIFF
--- a/read.go
+++ b/read.go
@@ -243,7 +243,7 @@ func ReadReaderAt[T ReadConfigurator](reader io.ReaderAt, size int64, filterFunc
 	if err != nil {
 		return nil, err
 	}
-	return read[T](f, filterFunc...)
+	return ReadParsed[T](f, filterFunc...)
 }
 
 // ReadFile opens an xlsx file at the given file path.
@@ -253,7 +253,7 @@ func ReadFile[T ReadConfigurator](file string, filterFunc ...func(t T) (add bool
 	if err != nil {
 		return nil, err
 	}
-	return read[T](f, filterFunc...)
+	return ReadParsed[T](f, filterFunc...)
 }
 
 // ReadBinary opens an xlsx file from the provided bytes.
@@ -263,7 +263,7 @@ func ReadBinary[T ReadConfigurator](bytes []byte, filterFunc ...func(t T) (add b
 	if err != nil {
 		return nil, err
 	}
-	return read[T](f, filterFunc...)
+	return ReadParsed[T](f, filterFunc...)
 }
 
 type fieldInfo struct {
@@ -272,7 +272,9 @@ type fieldInfo struct {
 	unmarshalFunc     UnmarshalExcelFunc
 }
 
-func read[T ReadConfigurator](f *xlsx.File, filterFunc ...func(t T) (add bool)) ([]T, error) {
+// ReadParsed opens an already parsed xlsx file directly.
+// Each row is parsed and unmarshalled into a slice of `T`.
+func ReadParsed[T ReadConfigurator](f *xlsx.File, filterFunc ...func(t T) (add bool)) ([]T, error) {
 	var t T
 	rc := defaultReadConfig()
 	t.ReadConfigure(rc)

--- a/read_test.go
+++ b/read_test.go
@@ -607,8 +607,8 @@ func TestReadFile(t *testing.T) {
 }
 
 func TestReadTrimSpace(t *testing.T) {
-	testFile := "tmp.xlsx"
-	defer func() { _ = os.Remove(testFile) }()
+	testFile := path.Join(t.TempDir(), "tmp.xlsx")
+
 	data := [][]string{
 		{"Name1", "Name2", "Name3", "Name4", "Name5"},
 		{"Name1 ", "Name2", "Name3", "Name4", "Name5"},
@@ -643,8 +643,8 @@ func (*missingColumnsNotAllowed) ReadConfigure(rc *ReadConfig) {
 }
 
 func TestReadSkipColumns(t *testing.T) {
-	testFile := "tmp.xlsx"
-	defer func() { _ = os.Remove(testFile) }()
+	testFile := path.Join(t.TempDir(), "tmp.xlsx")
+
 	data := [][]string{
 		{"Name1", "Name2", "Name3", "Name4", "Name5"},
 		{"Name1 ", "Name2", "Name3", "Name4", "Name5"},
@@ -693,8 +693,8 @@ func (*missingTypesNotAllowed) ReadConfigure(rc *ReadConfig) {
 }
 
 func TestReadSkipTypes(t *testing.T) {
-	testFile := "tmp.xlsx"
-	defer func() { _ = os.Remove(testFile) }()
+	testFile := path.Join(t.TempDir(), "tmp.xlsx")
+
 	data := [][]string{
 		{"Name1"},
 		{"Name1 Content"},
@@ -753,8 +753,8 @@ func (*collectUnmarshalErrorsUnlimited) ReadConfigure(rc *ReadConfig) {
 }
 
 func TestUnmarshalErrors(t *testing.T) {
-	testFile := "tmp.xlsx"
-	defer func() { _ = os.Remove(testFile) }()
+	testFile := path.Join(t.TempDir(), "tmp.xlsx")
+
 	data := [][]string{
 		{"Name1"},
 		{"error please"},
@@ -851,8 +851,8 @@ func TestUnmarshalErrors(t *testing.T) {
 }
 
 func TestReadFilterFunc(t *testing.T) {
-	testFile := "tmp.xlsx"
-	defer func() { _ = os.Remove(testFile) }()
+	testFile := path.Join(t.TempDir(), "tmp.xlsx")
+
 	data := [][]string{
 		{"Name1", "Name2", "Name3", "Name4", "Name5"},
 		{"Name11", "Name22", "Name33", "Name44", "Name55"},
@@ -896,28 +896,25 @@ func TestReadExcel(t *testing.T) {
 	}
 }
 
-func testBasic(testNum int) error {
-	testFile := "tmp.xlsx"
-	defer func() { _ = os.Remove(testFile) }()
-	data := make([][]string, testNum, testNum)
+func testBasic(t *testing.T, testNum int) {
+	testFile := path.Join(t.TempDir(), "tmp.xlsx")
+
+	data := make([][]string, testNum)
 	for i := range data {
 		data[i] = []string{fmt.Sprintf("%d", i)}
 	}
 	if err := WriteExcel(testFile, data); err != nil {
-		return err
+		t.Fatal(err.Error())
 	}
 	if err := ReadExcel(testFile, 0, func(index int, rows *xlsx.Row) {
-		if !reflect.DeepEqual(rows.GetCell(0).Value, fmt.Sprintf("%d", index)) {
-			panic("test failed")
-		}
+		equal(t, fmt.Sprintf("%d", index), rows.GetCell(0).Value)
 	}); err != nil {
-		return err
+		t.Fatal(err.Error())
 	}
-	return nil
 }
 
 func TestBasic(t *testing.T) {
-	_ = testBasic(10)
-	_ = testBasic(100)
-	_ = testBasic(10000)
+	testBasic(t, 10)
+	testBasic(t, 100)
+	testBasic(t, 10000)
 }


### PR DESCRIPTION
[feat: Don't copy the file to memory if possible](https://github.com/go-the-way/exl/commit/d87aaf97fa65c75ea753e076980be4c454f12255)

Where possible, pass readers to the xlsx library to read file content.  
Only copy the whole reader to memory if it cannot be avoided, when no file size is available.

[feat: Use t.TempDir() for temporary test file](https://github.com/go-the-way/exl/commit/287c90994df8daaa2ba8eee6c0ea1ec15ddcb960)

* Avoid collisions if two tests were to write in parallel
* Get automatic cleanup and error handling after the test run