### PR TITLE
feat: add SheetName to config

### DIFF
--- a/read.go
+++ b/read.go
@@ -29,6 +29,9 @@ type (
 		// The tag name to use when looking for fields in the target struct.
 		// Defaults to "excel".
 		TagName string
+		// Name of the worksheet to be read. Takes precedence over SheetIndex.
+		// Defaults to ""
+		SheetName string
 		// The index of the worksheet to be read.
 		// Defaults to 0, the first worksheet.
 		SheetIndex int
@@ -255,10 +258,19 @@ func ReadBinary[T ReadConfigurator](bytes []byte, filterFunc ...func(t T) (add b
 	var t T
 	rc := defaultReadConfig()
 	t.ReadConfigure(rc)
-	if rc.SheetIndex < 0 || rc.SheetIndex > len(f.Sheet)-1 {
+	sidx := rc.SheetIndex
+	if len(rc.SheetName) > 0 {
+		for idx, s := range f.Sheets {
+			if s.Name == rc.SheetName {
+				sidx = idx
+				break
+			}
+		}
+	}
+	if sidx < 0 || sidx > len(f.Sheet)-1 {
 		return nil, ErrSheetIndexOutOfRange
 	}
-	sheet := f.Sheets[rc.SheetIndex]
+	sheet := f.Sheets[sidx]
 	if rc.HeaderRowIndex < 0 || rc.HeaderRowIndex > sheet.MaxRow-1 {
 		return nil, ErrHeaderRowIndexOutOfRange
 	}

--- a/read_test.go
+++ b/read_test.go
@@ -35,13 +35,20 @@ type (
 	readSheetIndexOutOfRange        struct{}
 	readHeaderRowIndexOutOfRange    struct{}
 	readDataStartRowIndexOutOfRange struct{}
+	readSheetNameIndexOutOfRange    struct{}
 )
 
 func (t *readTmp) ReadConfigure(rc *ReadConfig) {
 	rc.TrimSpace = true
+	rc.SheetName = "Sheet1"
 }
 
 func (t *readSheetIndexOutOfRange) ReadConfigure(rc *ReadConfig) {
+	rc.SheetIndex = -1
+}
+
+func (t *readSheetNameIndexOutOfRange) ReadConfigure(rc *ReadConfig) {
+	rc.SheetName = "Some"
 	rc.SheetIndex = -1
 }
 
@@ -298,6 +305,9 @@ func TestReadFileErr(t *testing.T) {
 		t.Error("test failed")
 	}
 	if _, err := ReadFile[*readDataStartRowIndexOutOfRange](testFile); err != ErrDataStartRowIndexOutOfRange {
+		t.Error("test failed")
+	}
+	if _, err := ReadFile[*readSheetNameIndexOutOfRange](testFile); err != ErrSheetIndexOutOfRange {
 		t.Error("test failed")
 	}
 }


### PR DESCRIPTION
Adds `SheetName` to config to use instead of `SheetIndex`. If sheet with specified name wasn't found - falls back to using `SheetIndex`