### PR TITLE
feat: Allow ignoring fields when writing files

### DIFF
--- a/write_test.go
+++ b/write_test.go
@@ -13,6 +13,8 @@ package exl
 
 import (
 	"os"
+	"path"
+	"strings"
 	"testing"
 )
 
@@ -29,6 +31,38 @@ type writeReadTmp writeTmp
 func (*writeReadTmp) WriteConfigure(_ *WriteConfig) {}
 func (*writeReadTmp) ReadConfigure(_ *ReadConfig)   {}
 func (*writeTmp) WriteConfigure(_ *WriteConfig)     {}
+
+// Row type which ignored fields without tag.
+type writeWithIgnore struct {
+	Name1 string // This is ignored, should not be written
+	Name2 string `excel:"Name2"`
+}
+
+func (*writeWithIgnore) WriteConfigure(wc *WriteConfig) {
+	wc.IgnoreFieldsWithoutTag = true
+}
+
+// Row type for negative test, when a field does not have a tag
+// but the write configuration is set to write it anyway.
+type writeWithoutIgnore struct {
+	Name1 string // This is NOT ignored, should be written
+	Name2 string `excel:"Name2"`
+}
+
+func (*writeWithoutIgnore) WriteConfigure(wc *WriteConfig) {
+	wc.IgnoreFieldsWithoutTag = false
+}
+
+// Row type used below to inspect headers of otherwise empty files.
+// The error message is checked to make sure ignored columns don't get a header.
+type readNoFields struct {
+}
+
+func (*readNoFields) ReadConfigure(rc *ReadConfig) {
+	rc.SkipUnknownColumns = false
+	// "Read" the header to not get an error message immediately
+	rc.DataStartRowIndex = 0
+}
 
 func TestWriteErr(t *testing.T) {
 	testFile := "tmp.xlsx"
@@ -167,5 +201,91 @@ func TestWriteExcelTo(t *testing.T) {
 				t.Error("test failed: Name5 not equal")
 			}
 		}
+	}
+}
+
+func TestWriteIgnoringFieldsWithoutTag(t *testing.T) {
+	testFile := path.Join(t.TempDir(), "tmp.xlsx")
+
+	data := []*writeWithIgnore{
+		{"Name11", "Name22"},
+		{"Name111", "Name222"},
+		{"Name1111", "Name2222"},
+		{"Name11111", "Name22222"},
+		{"Name111111", "Name222222"},
+	}
+	if err := Write(testFile, data); err != nil {
+		t.Error("test failed: " + err.Error())
+	}
+	if models, err := ReadFile[*writeReadTmp](testFile); err != nil {
+		t.Error("test failed: " + err.Error())
+	} else if len(models) != len(data) {
+		t.Error("test failed")
+	} else {
+		for i, m := range models {
+			d := data[i]
+			// Name2 should not be in the excel file, so also not read
+			if m.Name1 != "" {
+				t.Error("test failed: Name1 not empty")
+			}
+			if d.Name2 != m.Name2 {
+				t.Error("test failed: Name2 not equal")
+			}
+		}
+	}
+}
+
+func TestWriteNotIgnoringFieldsWithoutTag(t *testing.T) {
+	testFile := path.Join(t.TempDir(), "tmp.xlsx")
+
+	data := []*writeWithoutIgnore{
+		{"Name11", "Name22"},
+		{"Name111", "Name222"},
+		{"Name1111", "Name2222"},
+		{"Name11111", "Name22222"},
+		{"Name111111", "Name222222"},
+	}
+	if err := Write(testFile, data); err != nil {
+		t.Error("test failed: " + err.Error())
+	}
+	if models, err := ReadFile[*writeReadTmp](testFile); err != nil {
+		t.Error("test failed: " + err.Error())
+	} else if len(models) != len(data) {
+		t.Error("test failed")
+	} else {
+		for i, m := range models {
+			d := data[i]
+			// Should not be ignored, even though it does not have a tag
+			if d.Name1 != m.Name1 {
+				t.Error("test failed: Name1 not equal")
+			}
+			if d.Name2 != m.Name2 {
+				t.Error("test failed: Name2 not equal")
+			}
+		}
+	}
+}
+
+// Ensure that for empty data sets, the write configuration is still done,
+// so that custom tag names (if configured) are not ignored,
+// and ignored fields (if configured) don't get headers.
+func TestWriteWithoutRowsConfiguresHeader(t *testing.T) {
+	testFile := path.Join(t.TempDir(), "tmp.xlsx")
+
+	// Write data without content, which should write only a header
+	data := []*writeWithIgnore{}
+	if err := Write(testFile, data); err != nil {
+		t.Error("test failed: " + err.Error())
+	}
+
+	// Read the file without any fields in the struct,
+	// which will give us an error message for the first column,
+	// which should be "Name2" as "Name1" is ignored and should not be in the file.
+	_, err := ReadFile[*readNoFields](testFile)
+	if err == nil {
+		t.Error("test failed, expected error")
+	}
+	if !strings.Contains(err.Error(), "Name2") {
+		t.Error("test failed, expected message for second column, got: " + err.Error())
 	}
 }


### PR DESCRIPTION
Changes write configuration processing to always run, even it, even if the provided data is empty.
If not done this way, empty files could have different headers compared to files with content, because the write config would not run.

Adds a write configuration `IgnoreFieldsWithoutTag`, which defaults to `false`, so the previous behaviour. If set to `true`, any fields which don't specify a tag (default `excel`) are not written to the output file.